### PR TITLE
Remove highlight border in video view

### DIFF
--- a/resources/xml/view/video_view.xml
+++ b/resources/xml/view/video_view.xml
@@ -3,7 +3,10 @@
     height="100%"
     axis="column"
     justifyContent="spaceBetween"
-    alignItems="center">
+    alignItems="center"
+    hideHighlight="true"
+    hideHighlightBorder="true"
+    hideHighlightBackground="true">
 
     <brls:Box
         id="video/osd/top/box"


### PR DESCRIPTION
Context: Whenever using dock mode, the selection highlight is often visible on all 4 corners, this PR fixes such minor annoyance