### PR TITLE
Fix: distorted multichannel audio on PS4

### DIFF
--- a/app/include/tab/setting_tab.hpp
+++ b/app/include/tab/setting_tab.hpp
@@ -41,6 +41,7 @@ private:
     BRLS_BIND(brls::BooleanCell, btnDirectPlay, "setting/video/directplay");
     BRLS_BIND(brls::SelectorCell, selectorVO, "setting/mpv/vo");
     BRLS_BIND(brls::SelectorCell, selectorCodec, "setting/transcode/codec");
+    BRLS_BIND(brls::SelectorCell, selectorAudioChannels, "setting/playback/audio_channels");
     BRLS_BIND(brls::SelectorCell, selectorInmemory, "setting/video/inmemory");
     BRLS_BIND(brls::SelectorCell, selectorVSync, "setting/ui/vsync");
     BRLS_BIND(brls::BooleanCell, btnBottomBar, "setting/ui/bottom_bar");

--- a/app/include/utils/config.hpp
+++ b/app/include/utils/config.hpp
@@ -66,6 +66,7 @@ public:
         APP_THEME,
         APP_LANG,
         APP_UPDATE,
+        AUDIO_CHANNELS,
         KEYMAP,
         WINDOW_STATE,
         TRANSCODEC,

--- a/app/include/view/mpv_core.hpp
+++ b/app/include/view/mpv_core.hpp
@@ -158,6 +158,11 @@ public:
     inline static int VIDEO_ROTATION = 0;
     // 强制的视频比例 (-1 为自动)
     inline static std::string VIDEO_ASPECT = "auto";
+#if defined(__PS4__)
+    inline static std::string AUDIO_CHANNELS = "stereo";
+#else
+    inline static std::string AUDIO_CHANNELS = "auto-safe";
+#endif
 
 private:
     mpv_handle *mpv = nullptr;

--- a/app/include/view/mpv_core.hpp
+++ b/app/include/view/mpv_core.hpp
@@ -158,11 +158,8 @@ public:
     inline static int VIDEO_ROTATION = 0;
     // 强制的视频比例 (-1 为自动)
     inline static std::string VIDEO_ASPECT = "auto";
-#if defined(__PS4__)
-    inline static std::string AUDIO_CHANNELS = "stereo";
-#else
+
     inline static std::string AUDIO_CHANNELS = "auto-safe";
-#endif
 
 private:
     mpv_handle *mpv = nullptr;

--- a/app/src/tab/setting_tab.cpp
+++ b/app/src/tab/setting_tab.cpp
@@ -199,14 +199,9 @@ void SettingTab::onCreate() {
         });
 #endif
     
-#ifdef PS4
-#define AUDIO_CHANNELS_DEFAULT_OPTION 1
-#else
-#define AUDIO_CHANNELS_DEFAULT_OPTION 0
-#endif
     auto& audioChannelsOption = conf.getOptions(AppConfig::AUDIO_CHANNELS);
     selectorAudioChannels->init("main/setting/playback/audio_channels"_i18n, {"Auto", "Stereo", "Mono"},
-        conf.getOptionIndex(AppConfig::AUDIO_CHANNELS, AUDIO_CHANNELS_DEFAULT_OPTION), [&audioChannelsOption](int selected) {
+        conf.getOptionIndex(AppConfig::AUDIO_CHANNELS), [&audioChannelsOption](int selected) {
             MPVCore::AUDIO_CHANNELS = audioChannelsOption.options[selected];
             AppConfig::instance().setItem(AppConfig::AUDIO_CHANNELS, MPVCore::AUDIO_CHANNELS);
             MPVCore::instance().restart();

--- a/app/src/tab/setting_tab.cpp
+++ b/app/src/tab/setting_tab.cpp
@@ -198,6 +198,19 @@ void SettingTab::onCreate() {
             AppConfig::instance().setItem(AppConfig::TRANSCODEC, MPVCore::VIDEO_CODEC);
         });
 #endif
+    
+#ifdef PS4
+#define AUDIO_CHANNELS_DEFAULT_OPTION 1
+#else
+#define AUDIO_CHANNELS_DEFAULT_OPTION 0
+#endif
+    auto& audioChannelsOption = conf.getOptions(AppConfig::AUDIO_CHANNELS);
+    selectorAudioChannels->init("main/setting/playback/audio_channels"_i18n, {"Auto", "Stereo", "Mono"},
+        conf.getOptionIndex(AppConfig::AUDIO_CHANNELS, AUDIO_CHANNELS_DEFAULT_OPTION), [&audioChannelsOption](int selected) {
+            MPVCore::AUDIO_CHANNELS = audioChannelsOption.options[selected];
+            AppConfig::instance().setItem(AppConfig::AUDIO_CHANNELS, MPVCore::AUDIO_CHANNELS);
+            MPVCore::instance().restart();
+        });
 
     auto& inmemoryOption = conf.getOptions(AppConfig::PLAYER_INMEMORY_CACHE);
     selectorInmemory->init("main/setting/playback/in_memory_cache"_i18n, inmemoryOption.options,

--- a/app/src/utils/config.cpp
+++ b/app/src/utils/config.cpp
@@ -65,6 +65,7 @@ std::unordered_map<AppConfig::Item, AppConfig::Option> AppConfig::settingMap = {
                    {brls::LOCALE_AUTO, brls::LOCALE_EN_US, brls::LOCALE_ZH_HANS, brls::LOCALE_ZH_HANT, brls::LOCALE_JA,
                        brls::LOCALE_Ko, brls::LOCALE_DE, brls::LOCALE_PT_BR, "cs", "uk-UA", "vi_VN"}}},
     {APP_UPDATE, {"app_update"}},
+    {AUDIO_CHANNELS, {"audio-channels", {"auto-safe", "stereo", "mono"}}},
     {KEYMAP, {"keymap", {"xbox", "ps", "keyboard"}}},
     {WINDOW_STATE, {"window_state"}},
     {TRANSCODEC, {"transcodec", {"h264", "hevc", "av1"}}},
@@ -291,6 +292,8 @@ bool AppConfig::init() {
     MPVCore::HARDWARE_DEC = this->getItem(PLAYER_HWDEC, true);
     MPVCore::FORCE_DIRECTPLAY = this->getItem(FORCE_DIRECTPLAY, false);
     MPVCore::VIDEO_CODEC = this->getItem(TRANSCODEC, MPVCore::VIDEO_CODEC);
+
+    MPVCore::AUDIO_CHANNELS = this->getItem(AUDIO_CHANNELS, MPVCore::AUDIO_CHANNELS);
 
     // 初始化自定义的硬件加速方案
     MPVCore::PLAYER_HWDEC_METHOD = this->getItem(PLAYER_HWDEC_CUSTOM, MPVCore::PLAYER_HWDEC_METHOD);

--- a/app/src/view/mpv_core.cpp
+++ b/app/src/view/mpv_core.cpp
@@ -103,6 +103,8 @@ void MPVCore::init() {
     mpv_set_option_string(mpv, "subs-fallback", SUBS_FALLBACK ? "yes" : "no");
     mpv_set_option_string(mpv, "vo", MPVCore::VO.c_str());
 
+    mpv_set_option_string(mpv, "audio-channels", MPVCore::AUDIO_CHANNELS.c_str());
+
     if (MPVCore::LOW_QUALITY) {
         // Less cpu cost
         brls::Logger::info("lavc: skip loop filter and set fast decode");

--- a/resources/i18n/cs/main.json
+++ b/resources/i18n/cs/main.json
@@ -103,7 +103,8 @@
       "clip_point": "Zobrazit bod klipu kapitoly",
       "transcodec": "Transcodec",
       "video_quality": "Kvalita videa",
-      "subsync": "Synchronizace titulků"
+      "subsync": "Synchronizace titulků",
+      "audio_channels": "Zvukové kanály"
     },
     "filter": {
       "mirror": "Překlopení videa",

--- a/resources/i18n/de/main.json
+++ b/resources/i18n/de/main.json
@@ -65,7 +65,8 @@
       "hwdec": "Hardwaredekodierung",
       "osd_on_toggle": "Zeige OSD wenn pausiert",
       "transcodec": "Transcodec",
-      "maxbitrate": "Max Bitrate"
+      "maxbitrate": "Max Bitrate",
+      "audio_channels": "Audiokanäle"
     },
     "network": {
       "header": "Netzwerk",

--- a/resources/i18n/en-US/main.json
+++ b/resources/i18n/en-US/main.json
@@ -146,6 +146,7 @@
       "touch_gesture": "Touch gesture for seeking step",
       "clip_point": "Show clip point of chapter",
       "transcodec": "Codec",
+      "audio_channels": "Audio Channels",
       "video_quality": "Video Quality",
       "subsync": "Subtitle Sync"
     },

--- a/resources/i18n/ja/main.json
+++ b/resources/i18n/ja/main.json
@@ -147,7 +147,8 @@
       "clip_point": "チャプターのクリップポイントを表示",
       "transcodec": "トランスコーデック",
       "video_quality": "ビデオ品質",
-      "subsync": "字幕同期"
+      "subsync": "字幕同期",
+      "audio_channels": "オーディオチャンネル"
     },
     "transcode": {
       "header": "トランスコーディングプロファイル"

--- a/resources/i18n/ko/main.json
+++ b/resources/i18n/ko/main.json
@@ -145,6 +145,7 @@
       "touch_gesture": "재생 진행 손가락 제스처 활성화",
       "clip_point": "챕터 위치 표시",
       "transcodec": "트랜스코딩 포맷",
+      "audio_channels": "오디오 채널",  
       "video_quality": "비디오 품질",
       "subsync": "자막 동기화"
     },

--- a/resources/i18n/pt-BR/main.json
+++ b/resources/i18n/pt-BR/main.json
@@ -132,6 +132,7 @@
       "touch_gesture": "Gestos de toque para pular",
       "clip_point": "Mostrar ponto de clipe do capítulo",
       "transcodec": "Codec",
+      "audio_channels": "Canais de Áudio",
       "video_quality": "Qualidade do Vídeo",
       "subsync": "Sincronização de Legendas"
     },

--- a/resources/i18n/uk-UA/main.json
+++ b/resources/i18n/uk-UA/main.json
@@ -90,6 +90,7 @@
       "force_directplay": "Примусове пряме відтворення",
       "osd_on_toggle": "Показати екранне меню під час паузи",
       "transcodec": "Транскодек",
+      "audio_channels": "Аудіоканали",
       "video_quality": "Якість відео"
     },
     "network": {

--- a/resources/i18n/vi_VN/main.json
+++ b/resources/i18n/vi_VN/main.json
@@ -129,6 +129,7 @@
       "touch_gesture": "Cảm ứng để tua nhanh",
       "clip_point": "Hiển thị các chương trong video",
       "transcodec": "Chuyển mã",
+      "audio_channels": "Kênh âm thanh",
       "video_quality": "Chất lượng video",
       "subsync": "Đồng bộ phụ đề"
     },

--- a/resources/i18n/zh-Hans/main.json
+++ b/resources/i18n/zh-Hans/main.json
@@ -146,6 +146,7 @@
       "touch_gesture": "启用播放进度手势",
       "clip_point": "进度条显示章节位置",
       "transcodec": "转码格式",
+      "audio_channels": "音频通道",
       "video_quality": "视频质量",
       "subsync": "字幕同步"
     },

--- a/resources/i18n/zh-Hant/main.json
+++ b/resources/i18n/zh-Hant/main.json
@@ -150,6 +150,7 @@
       "touch_gesture": "啟用播放進度手勢",
       "clip_point": "進度條顯示章節位置",
       "transcodec": "轉碼格式",
+      "audio_channels": "音訊通道",
       "video_quality": "視頻質量",
       "subsync": "字幕同步"
     },

--- a/resources/xml/tabs/settings.xml
+++ b/resources/xml/tabs/settings.xml
@@ -52,6 +52,8 @@
                     id="setting/video/inmemory" />
                 <brls:BooleanCell
                     id="setting/video/subs_fallback" />
+                 <brls:SelectorCell
+                    id="setting/playback/audio_channels" />
                 <brls:BooleanCell
                     id="setting/player/osd_on_toggle" />
                 <brls:BooleanCell


### PR DESCRIPTION
Added setting to configure mpv's `audio-channels` option for video playback: https://mpv.io/manual/master/#options-audio-channels
You can set one of the following options: 
- "Auto"  (default)
- "Stereo" (default for PS4)
- "Mono"

Setting `audio-channels` to Stereo resolves playback issue on PS4, where multichannel audio leads to distorted output (Issue #107). 