### PR TITLE
Download manager improvements

### DIFF
--- a/app/include/utils/download.hpp
+++ b/app/include/utils/download.hpp
@@ -48,6 +48,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(DownloadItem, itemId, name, type
 
 namespace jellyfin {
 struct Item;
+struct Episode;
 }
 
 class DownloadManager : public brls::Singleton<DownloadManager> {
@@ -58,6 +59,7 @@ public:
     void init();
 
     void addDownload(const jellyfin::Item& item, DownloadQuality quality);
+    void addDownload(const jellyfin::Episode& item, DownloadQuality quality);
     void cancelDownload(const std::string& itemId);
     void removeDownload(const std::string& itemId);
     void resumeQueue();

--- a/app/include/view/context_menu.hpp
+++ b/app/include/view/context_menu.hpp
@@ -8,12 +8,15 @@ class ButtonClose;
 class ContextMenu : public brls::Box {
 public:
     ContextMenu(const jellyfin::Item& item);
+    ContextMenu(const jellyfin::Episode& episode);
 
     bool isTranslucent() override { return true; }
 
     View* getDefaultFocus() override { return this->context->getDefaultFocus(); }
 
 private:
+    void setup(const jellyfin::Item& item);
+
     BRLS_BIND(brls::ScrollingFrame, context, "video/context/menu");
     BRLS_BIND(brls::Box, cancel, "video/cancel");
 
@@ -28,4 +31,8 @@ private:
 
     std::string itemId;
     jellyfin::Item item;
+    std::string episodeSeriesName;
+    int episodeSeasonIndex = 0;
+    int episodeIndex = 0;
+    bool hasEpisodeData = false;
 };

--- a/app/src/activity/server_list.cpp
+++ b/app/src/activity/server_list.cpp
@@ -143,8 +143,7 @@ void ServerList::onContentAvailable() {
         return true;
     });
 
-    if (AppConfig::instance().getRemotes().empty() || brls::Application::getActivitiesStack().size() > 1) {
-        // Hide the remote tab if there are no remotes
+    if (brls::Application::getActivitiesStack().size() > 1) {
         brls::View* tab = this->getView("tab/remote");
         if (tab) tab->setVisibility(brls::Visibility::GONE);
     }

--- a/app/src/tab/download_tab.cpp
+++ b/app/src/tab/download_tab.cpp
@@ -116,10 +116,14 @@ public:
                 auto* profile = view->getProfile();
                 auto& mpv = MPVCore::instance();
                 auto subId = std::make_shared<MPVEvent::Subscription>();
-                *subId = mpv.getEvent()->subscribe([profile, subId](MpvEventEnum event) {
+                auto unsub = std::make_shared<std::atomic_bool>(false);
+                *subId = mpv.getEvent()->subscribe([profile, subId, unsub](MpvEventEnum event) {
+                    if (unsub->load()) return;
                     if (event == MpvEventEnum::MPV_RESUME) {
                         profile->init("Local");
-                    } else if (event == MpvEventEnum::MPV_STOP) {
+                    } else if (event == MpvEventEnum::MPV_STOP || event == MpvEventEnum::END_OF_FILE ||
+                               event == MpvEventEnum::MPV_FILE_ERROR) {
+                        unsub->store(true);
                         auto id = *subId;
                         brls::sync([id]() {
                             MPVCore::instance().getEvent()->unsubscribe(id);

--- a/app/src/tab/download_tab.cpp
+++ b/app/src/tab/download_tab.cpp
@@ -120,7 +120,10 @@ public:
                     if (event == MpvEventEnum::MPV_RESUME) {
                         profile->init("Local");
                     } else if (event == MpvEventEnum::MPV_STOP) {
-                        MPVCore::instance().getEvent()->unsubscribe(*subId);
+                        auto id = *subId;
+                        brls::sync([id]() {
+                            MPVCore::instance().getEvent()->unsubscribe(id);
+                        });
                     }
                 });
 

--- a/app/src/tab/download_tab.cpp
+++ b/app/src/tab/download_tab.cpp
@@ -2,6 +2,7 @@
 #include "view/recycling_grid.hpp"
 #include "view/video_view.hpp"
 #include "view/mpv_core.hpp"
+#include "view/video_profile.hpp"
 #include "view/player_setting.hpp"
 #include "utils/config.hpp"
 #include "utils/dialog.hpp"
@@ -115,6 +116,13 @@ public:
                 view->getPlayEvent()->subscribe([](int) { return VideoView::close(true); });
                 view->getSettingEvent()->subscribe([]() {
                     brls::Application::pushActivity(new brls::Activity(new PlayerSetting()));
+                });
+
+                auto* profile = view->getProfile();
+                MPVCore::instance().getEvent()->subscribe([profile](MpvEventEnum event) {
+                    if (event == MpvEventEnum::MPV_RESUME) {
+                        profile->init("Local");
+                    }
                 });
 
                 brls::Box* container = new brls::Box();

--- a/app/src/tab/download_tab.cpp
+++ b/app/src/tab/download_tab.cpp
@@ -113,16 +113,20 @@ public:
                 view->setTitie(item.name);
                 view->hideVideoQuality();
 
+                auto* profile = view->getProfile();
+                auto& mpv = MPVCore::instance();
+                auto subId = std::make_shared<MPVEvent::Subscription>();
+                *subId = mpv.getEvent()->subscribe([profile, subId](MpvEventEnum event) {
+                    if (event == MpvEventEnum::MPV_RESUME) {
+                        profile->init("Local");
+                    } else if (event == MpvEventEnum::MPV_STOP) {
+                        MPVCore::instance().getEvent()->unsubscribe(*subId);
+                    }
+                });
+
                 view->getPlayEvent()->subscribe([](int) { return VideoView::close(true); });
                 view->getSettingEvent()->subscribe([]() {
                     brls::Application::pushActivity(new brls::Activity(new PlayerSetting()));
-                });
-
-                auto* profile = view->getProfile();
-                MPVCore::instance().getEvent()->subscribe([profile](MpvEventEnum event) {
-                    if (event == MpvEventEnum::MPV_RESUME) {
-                        profile->init("Local");
-                    }
                 });
 
                 brls::Box* container = new brls::Box();

--- a/app/src/tab/media_series.cpp
+++ b/app/src/tab/media_series.cpp
@@ -13,6 +13,8 @@
 #include "view/people_source.hpp"
 #include "view/video_source.hpp"
 #include "view/presenter.hpp"
+#include "view/context_menu.hpp"
+#include "utils/keybind.hpp"
 #include <fmt/ranges.h>
 
 using namespace brls::literals;  // for _i18n
@@ -90,6 +92,12 @@ public:
         brls::sync([view]() { brls::Application::giveFocus(view); });
     }
 
+    void onContextMenu(brls::Box* recycler, size_t index) {
+        auto& item = this->list.at(index);
+        brls::Box* menu = new ContextMenu(item);
+        brls::Application::pushActivity(new brls::Activity(menu));
+    }
+
     void clearData() override { this->list.clear(); }
 
     void appendData(const MediaList& data) { this->list.insert(this->list.end(), data.begin(), data.end()); }
@@ -104,6 +112,19 @@ public:
         this->inflateFromXMLRes("xml/tabs/seasons.xml");
 
         this->recycler->registerCell("Cell", EpisodeCardCell::create);
+
+        auto contextAction = [this](brls::View*) {
+            auto* focus = dynamic_cast<RecyclingGridItem*>(brls::Application::getCurrentFocus());
+            if (!focus) return false;
+            auto* ds = dynamic_cast<EpisodeDataSource*>(this->recycler->getDataSource());
+            if (!ds) return false;
+            size_t idx = focus->getIndex();
+            if (idx >= ds->getItemCount()) return false;
+            ds->onContextMenu(this->recycler, idx);
+            return true;
+        };
+        this->recycler->registerAction("hints/submit"_i18n, brls::BUTTON_X, contextAction, true);
+        this->recycler->registerAction(KeyBind::getSetting(), contextAction);
     }
 
     void onCreate() override {

--- a/app/src/utils/download.cpp
+++ b/app/src/utils/download.cpp
@@ -90,6 +90,39 @@ void DownloadManager::addDownload(const jellyfin::Item& item, DownloadQuality qu
     this->processQueue();
 }
 
+void DownloadManager::addDownload(const jellyfin::Episode& item, DownloadQuality quality) {
+    std::lock_guard<std::mutex> lock(this->mutex);
+
+    for (auto& existing : this->items) {
+        if (existing.itemId == item.Id) {
+            brls::Logger::info("Download already exists: {}", item.Name);
+            return;
+        }
+    }
+
+    DownloadItem dl;
+    dl.itemId = item.Id;
+    dl.name = item.Name;
+    dl.type = item.Type;
+    dl.productionYear = item.ProductionYear;
+    dl.runTimeTicks = item.RunTimeTicks;
+    dl.quality = quality;
+    dl.status = DownloadStatus::Queued;
+    dl.seriesName = item.SeriesName;
+    dl.seasonIndex = item.ParentIndexNumber;
+    dl.episodeIndex = item.IndexNumber;
+
+    auto primaryTag = item.ImageTags.find(jellyfin::imageTypePrimary);
+    if (primaryTag != item.ImageTags.end()) {
+        dl.imagePrimaryTag = primaryTag->second;
+    }
+
+    this->items.push_back(dl);
+    this->saveIndex();
+    brls::Logger::info("Download queued: {}", item.Name);
+    this->processQueue();
+}
+
 void DownloadManager::resumeQueue() {
     std::lock_guard<std::mutex> lock(this->mutex);
     this->processQueue();

--- a/app/src/view/context_menu.cpp
+++ b/app/src/view/context_menu.cpp
@@ -5,6 +5,19 @@
 using namespace brls::literals;
 
 ContextMenu::ContextMenu(const jellyfin::Item& item) : itemId(item.Id), item(item) {
+    this->setup(item);
+}
+
+ContextMenu::ContextMenu(const jellyfin::Episode& episode)
+    : itemId(episode.Id), item(episode),
+      episodeSeriesName(episode.SeriesName),
+      episodeSeasonIndex(episode.ParentIndexNumber),
+      episodeIndex(episode.IndexNumber),
+      hasEpisodeData(true) {
+    this->setup(episode);
+}
+
+void ContextMenu::setup(const jellyfin::Item& item) {
     this->inflateFromXMLRes("xml/view/context_menu.xml");
     brls::Logger::debug("ContextMenu: create");
 
@@ -54,7 +67,16 @@ ContextMenu::ContextMenu(const jellyfin::Item& item) : itemId(item.Id), item(ite
                 brls::Application::notify("main/download/downloading"_i18n);
             } else {
                 int qi = AppConfig::instance().getValueIndex(AppConfig::DOWNLOAD_QUALITY);
-                dm.addDownload(this->item, static_cast<DownloadQuality>(qi));
+                if (this->hasEpisodeData) {
+                    jellyfin::Episode ep;
+                    static_cast<jellyfin::Item&>(ep) = this->item;
+                    ep.SeriesName = this->episodeSeriesName;
+                    ep.ParentIndexNumber = this->episodeSeasonIndex;
+                    ep.IndexNumber = this->episodeIndex;
+                    dm.addDownload(ep, static_cast<DownloadQuality>(qi));
+                } else {
+                    dm.addDownload(this->item, static_cast<DownloadQuality>(qi));
+                }
                 brls::Application::notify("main/download/queued"_i18n);
                 this->btnDownload->setSelected(true);
             }


### PR DESCRIPTION
Follow-up to #209. This addresses the immediate gaps mentioned there and fixes a few issues found during testing.

- Diagnostic overlay (F1) now works during offline playback, showing codec, resolution, bitrate and other local file metrics.
- Episodes can be downloaded directly from the series/season view via the context menu (F4/X), with proper series name and episode numbering preserved in the downloads list.
- Downloads are accessible in airplane mode — the Remote tab is now visible on the server selection screen so downloaded media can be played without a Jellyfin connection.
- Fixed a crash when exiting offline playback caused by an event subscription outliving the player view.