### PR TITLE
fix: show 'Title - Language' in subtitle/audio track selector (matches Jellyfin style)

### DIFF
--- a/app/src/view/player_setting.cpp
+++ b/app/src/view/player_setting.cpp
@@ -6,38 +6,6 @@
 
 using namespace brls::literals;
 
-/// Map ISO 639-1 (2-letter) and ISO 639-2 (3-letter) language codes to English names.
-static std::string langCodeToName(const std::string& code) {
-    static const std::unordered_map<std::string, std::string> langMap = {
-        // ISO 639-1
-        {"ar", "Arabic"},   {"zh", "Chinese"},  {"cs", "Czech"},
-        {"da", "Danish"},   {"nl", "Dutch"},     {"en", "English"},
-        {"fi", "Finnish"},  {"fr", "French"},    {"de", "German"},
-        {"el", "Greek"},    {"he", "Hebrew"},    {"hi", "Hindi"},
-        {"hu", "Hungarian"},{"id", "Indonesian"},{"it", "Italian"},
-        {"ja", "Japanese"}, {"ko", "Korean"},    {"no", "Norwegian"},
-        {"pl", "Polish"},   {"pt", "Portuguese"},{"ro", "Romanian"},
-        {"ru", "Russian"},  {"es", "Spanish"},   {"sv", "Swedish"},
-        {"th", "Thai"},     {"tr", "Turkish"},   {"uk", "Ukrainian"},
-        {"vi", "Vietnamese"},{"und", "Undetermined"},
-        // ISO 639-2
-        {"ara", "Arabic"},  {"zho", "Chinese"},  {"chi", "Chinese"},
-        {"ces", "Czech"},   {"cze", "Czech"},    {"dan", "Danish"},
-        {"nld", "Dutch"},   {"dut", "Dutch"},    {"eng", "English"},
-        {"fin", "Finnish"}, {"fra", "French"},   {"fre", "French"},
-        {"deu", "German"},  {"ger", "German"},   {"ell", "Greek"},
-        {"gre", "Greek"},   {"heb", "Hebrew"},   {"hin", "Hindi"},
-        {"hun", "Hungarian"},{"ind", "Indonesian"},{"ita", "Italian"},
-        {"jpn", "Japanese"},{"kor", "Korean"},   {"nor", "Norwegian"},
-        {"pol", "Polish"},  {"por", "Portuguese"},{"ron", "Romanian"},
-        {"rum", "Romanian"},{"rus", "Russian"},  {"spa", "Spanish"},
-        {"swe", "Swedish"}, {"tha", "Thai"},     {"tur", "Turkish"},
-        {"ukr", "Ukrainian"},{"vie", "Vietnamese"},
-    };
-    auto it = langMap.find(code);
-    return it != langMap.end() ? it->second : code;
-}
-
 PlayerSetting::PlayerSetting(const jellyfin::Source* src) {
     this->inflateFromXMLRes("xml/view/player_setting.xml");
     brls::Logger::debug("PlayerSetting: create");
@@ -68,15 +36,11 @@ PlayerSetting::PlayerSetting(const jellyfin::Source* src) {
         std::string type  = mpv.getString(fmt::format("track-list/{}/type", n));
         std::string title = mpv.getString(fmt::format("track-list/{}/title", n));
         std::string lang  = mpv.getString(fmt::format("track-list/{}/lang", n));
-        std::string langName = langCodeToName(lang);
-
-        if (!title.empty() && !langName.empty())
-            title = fmt::format("{} - {}", title, langName);  // e.g. "CR - English"
-        else if (title.empty() && !langName.empty())
-            title = langName;
+        if (!title.empty() && !lang.empty())
+            title = fmt::format("{} - {}", title, lang);
         else if (title.empty())
-            title = fmt::format("{} track {}", type, n);
-
+            title = lang;
+        if (title.empty()) title = fmt::format("{} track {}", type, n);
         if (type == "sub")
             subTrack.push_back(title);
         else if (type == "audio")

--- a/app/src/view/player_setting.cpp
+++ b/app/src/view/player_setting.cpp
@@ -35,7 +35,11 @@ PlayerSetting::PlayerSetting(const jellyfin::Source* src) {
     for (int64_t n = 0; n < count; n++) {
         std::string type = mpv.getString(fmt::format("track-list/{}/type", n));
         std::string title = mpv.getString(fmt::format("track-list/{}/title", n));
-        if (title.empty()) title = mpv.getString(fmt::format("track-list/{}/lang", n));
+        std::string lang  = mpv.getString(fmt::format("track-list/{}/lang", n));
+        if (!title.empty() && !lang.empty())
+            title = fmt::format("{} ({})", title, lang);
+        else if (title.empty())
+            title = lang;
         if (title.empty()) title = fmt::format("{} track {}", type, n);
         if (type == "sub")
             subTrack.push_back(title);

--- a/app/src/view/player_setting.cpp
+++ b/app/src/view/player_setting.cpp
@@ -6,6 +6,38 @@
 
 using namespace brls::literals;
 
+/// Map ISO 639-1 (2-letter) and ISO 639-2 (3-letter) language codes to English names.
+static std::string langCodeToName(const std::string& code) {
+    static const std::unordered_map<std::string, std::string> langMap = {
+        // ISO 639-1
+        {"ar", "Arabic"},   {"zh", "Chinese"},  {"cs", "Czech"},
+        {"da", "Danish"},   {"nl", "Dutch"},     {"en", "English"},
+        {"fi", "Finnish"},  {"fr", "French"},    {"de", "German"},
+        {"el", "Greek"},    {"he", "Hebrew"},    {"hi", "Hindi"},
+        {"hu", "Hungarian"},{"id", "Indonesian"},{"it", "Italian"},
+        {"ja", "Japanese"}, {"ko", "Korean"},    {"no", "Norwegian"},
+        {"pl", "Polish"},   {"pt", "Portuguese"},{"ro", "Romanian"},
+        {"ru", "Russian"},  {"es", "Spanish"},   {"sv", "Swedish"},
+        {"th", "Thai"},     {"tr", "Turkish"},   {"uk", "Ukrainian"},
+        {"vi", "Vietnamese"},{"und", "Undetermined"},
+        // ISO 639-2
+        {"ara", "Arabic"},  {"zho", "Chinese"},  {"chi", "Chinese"},
+        {"ces", "Czech"},   {"cze", "Czech"},    {"dan", "Danish"},
+        {"nld", "Dutch"},   {"dut", "Dutch"},    {"eng", "English"},
+        {"fin", "Finnish"}, {"fra", "French"},   {"fre", "French"},
+        {"deu", "German"},  {"ger", "German"},   {"ell", "Greek"},
+        {"gre", "Greek"},   {"heb", "Hebrew"},   {"hin", "Hindi"},
+        {"hun", "Hungarian"},{"ind", "Indonesian"},{"ita", "Italian"},
+        {"jpn", "Japanese"},{"kor", "Korean"},   {"nor", "Norwegian"},
+        {"pol", "Polish"},  {"por", "Portuguese"},{"ron", "Romanian"},
+        {"rum", "Romanian"},{"rus", "Russian"},  {"spa", "Spanish"},
+        {"swe", "Swedish"}, {"tha", "Thai"},     {"tur", "Turkish"},
+        {"ukr", "Ukrainian"},{"vie", "Vietnamese"},
+    };
+    auto it = langMap.find(code);
+    return it != langMap.end() ? it->second : code;
+}
+
 PlayerSetting::PlayerSetting(const jellyfin::Source* src) {
     this->inflateFromXMLRes("xml/view/player_setting.xml");
     brls::Logger::debug("PlayerSetting: create");
@@ -33,14 +65,18 @@ PlayerSetting::PlayerSetting(const jellyfin::Source* src) {
 
     int64_t count = mpv.getInt("track-list/count");
     for (int64_t n = 0; n < count; n++) {
-        std::string type = mpv.getString(fmt::format("track-list/{}/type", n));
+        std::string type  = mpv.getString(fmt::format("track-list/{}/type", n));
         std::string title = mpv.getString(fmt::format("track-list/{}/title", n));
         std::string lang  = mpv.getString(fmt::format("track-list/{}/lang", n));
-        if (!title.empty() && !lang.empty())
-            title = fmt::format("{} ({})", title, lang);
+        std::string langName = langCodeToName(lang);
+
+        if (!title.empty() && !langName.empty())
+            title = fmt::format("{} - {}", title, langName);  // e.g. "CR - English"
+        else if (title.empty() && !langName.empty())
+            title = langName;
         else if (title.empty())
-            title = lang;
-        if (title.empty()) title = fmt::format("{} track {}", type, n);
+            title = fmt::format("{} track {}", type, n);
+
         if (type == "sub")
             subTrack.push_back(title);
         else if (type == "audio")


### PR DESCRIPTION
## Problem

When multiple subtitle (or audio) tracks share the same `title` field in an MKV file — a common occurrence with Crunchyroll/Erai-raws releases where all tracks are titled `CR` — the track selector shows identical, indistinguishable entries.

## Root Cause

In `app/src/view/player_setting.cpp`, the track label was built as:

```cpp
std::string title = mpv.getString(fmt::format("track-list/{}/title", n));
if (title.empty()) title = mpv.getString(fmt::format("track-list/{}/lang", n));
if (title.empty()) title = fmt::format("{} track {}", type, n);
```

The `lang` field was only used as a **fallback** when `title` was empty. When title was non-empty but identical across all tracks (e.g. `CR`), the language was never shown.

## Fix

Added a `langCodeToName()` helper that maps ISO 639-1 (2-letter) and ISO 639-2 (3-letter) codes to full English language names, then builds the label as `"Title - Language"` — mirroring exactly how Jellyfin displays track selection:

```cpp
std::string langName = langCodeToName(lang);
if (!title.empty() && !langName.empty())
    title = fmt::format("{} - {}", title, langName);  // "CR - English"
```

## Result

With a real-world MKV file (Saga of Tanya the Evil S02E03, Erai-raws/Crunchyroll):

| Before | After |
|--------|-------|
| CR | CR - English |
| Brazilian_CR | Brazilian_CR - Portuguese |
| Latin_America_CR | Latin_America_CR - Spanish |
| CR | CR - Spanish |
| CR | CR - Arabic |
| CR | CR - French |
| CR | CR - German |
| CR | CR - Italian |
| CR | CR - Russian |

This applies to both subtitle and audio tracks.