### PR TITLE
feat(download): auto-download subtitles and support attaching local/remote subtitles for downloaded items

### DIFF
--- a/app/include/tab/remote_view.hpp
+++ b/app/include/tab/remote_view.hpp
@@ -25,7 +25,7 @@ public:
 
     void dismiss(std::function<void(void)> cb = [] {}) override;
 
-    static void play(const std::string& path, const std::string& name = "");
+    static void play(const std::string& path, const std::string& name = "", const std::string& itemId = "");
 
 protected:
     void setContent(RecyclingGrid* view);

--- a/app/src/tab/download_tab.cpp
+++ b/app/src/tab/download_tab.cpp
@@ -244,7 +244,7 @@ public:
             } else {
                 detail = item.name;
             }
-            RemoteView::play(path, detail);
+            RemoteView::play(path, detail, item.itemId);
         } else if (item.status == DownloadStatus::Downloading) {
             std::string id = item.itemId;
             Dialog::cancelable(

--- a/app/src/tab/remote_view.cpp
+++ b/app/src/tab/remote_view.cpp
@@ -12,12 +12,13 @@
 #include "utils/thread.hpp"
 #include "utils/misc.hpp"
 #include "utils/config.hpp"
+#include "api/jellyfin.hpp"
 
 using namespace brls::literals;
 
 class RemotePlayer : public brls::Box {
 public:
-    RemotePlayer(const remote::DirEntry& item) {
+    RemotePlayer(const remote::DirEntry& item, const std::string& itemId = "") : itemId(itemId) {
         float width = brls::Application::contentWidth;
         float height = brls::Application::contentHeight;
         view->setDimensions(width, height);
@@ -45,6 +46,42 @@ public:
                 const char* flag = MPVCore::SUBS_FALLBACK ? "select" : "auto";
                 for (auto& it : this->subtitles) {
                     mpv.command("sub-add", it.second.c_str(), flag, it.first.c_str());
+                }
+
+                // Load all subtitle files (.srt, .vtt, .ass, .sub) found in the item's local folder
+                std::string itemDir = this->url;
+                auto pos = itemDir.find_last_of("/\\");
+                if (pos != std::string::npos) {
+                    itemDir = itemDir.substr(0, pos);
+                    if (fs::exists(itemDir) && fs::is_directory(itemDir)) {
+                        for (const auto& entry : fs::directory_iterator(itemDir)) {
+                            std::string ext = entry.path().extension().string();
+                            std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+                            if (ext == ".srt" || ext == ".vtt" || ext == ".ass" || ext == ".sub") {
+                                std::string filename = entry.path().filename().string();
+                                mpv.command("sub-add", entry.path().string().c_str(), flag, filename.c_str());
+                            }
+                        }
+                    }
+                }
+
+                // If item has a Jellyfin item ID and user is logged in, attach remote server subtitles
+                if (!this->itemId.empty() && AppConfig::instance().checkLogin()) {
+                    std::string itemId = this->itemId;
+                    jellyfin::getJSON<jellyfin::Detail>(
+                        [flag](const jellyfin::Detail& detail) {
+                            auto& mpv = MPVCore::instance();
+                            auto& svr = AppConfig::instance().getUrl();
+                            for (const auto& src : detail.MediaSources) {
+                                for (const auto& s : src.MediaStreams) {
+                                    if (s.Type == jellyfin::streamTypeSubtitle && !s.DeliveryUrl.empty()) {
+                                        std::string subUrl = svr + s.DeliveryUrl;
+                                        mpv.command("sub-add", subUrl.c_str(), flag, s.DisplayTitle.c_str());
+                                    }
+                                }
+                            }
+                        },
+                        nullptr, jellyfin::apiUserItem, AppConfig::instance().getUserId(), itemId);
                 }
                 break;
             }
@@ -148,6 +185,7 @@ public:
     }
 
 private:
+    std::string itemId;
     VideoView* view = new VideoView();
     std::string url;
     std::vector<std::string> titles;
@@ -411,8 +449,8 @@ RecyclingGrid* RemoteView::newRecycler() {
     return view;
 }
 
-void RemoteView::play(const std::string& path, const std::string& name) {
-    RemotePlayer* view = new RemotePlayer({remote::EntryType::VIDEO, name, path});
+void RemoteView::play(const std::string& path, const std::string& name, const std::string& itemId) {
+    RemotePlayer* view = new RemotePlayer({remote::EntryType::VIDEO, name, path}, itemId);
     brls::Application::pushActivity(new brls::Activity(view), brls::TransitionAnimation::NONE);
     view->setUrl(path);
 }

--- a/app/src/utils/download.cpp
+++ b/app/src/utils/download.cpp
@@ -363,6 +363,35 @@ void DownloadManager::doDownload(DownloadItem& item) {
             }
         }
 
+        if (!cancel->load()) {
+            try {
+                auto resp = HTTP::get(
+                    conf.getUrl() + fmt::format(fmt::runtime(jellyfin::apiUserItem), conf.getUserId(), itemId),
+                    header, HTTP::Timeout{});
+                if (!resp.empty()) {
+                    auto detail = nlohmann::json::parse(resp).get<jellyfin::Detail>();
+                    for (const auto& src : detail.MediaSources) {
+                        for (const auto& stream : src.MediaStreams) {
+                            if (stream.Type == jellyfin::streamTypeSubtitle && !stream.DeliveryUrl.empty()) {
+                                std::string subUrl = conf.getUrl() + stream.DeliveryUrl;
+                                std::string subExt = "srt";
+                                if (!stream.Codec.empty()) subExt = stream.Codec;
+                                std::string subFileName = fmt::format("sub_{}.{}", stream.Index, subExt);
+                                try {
+                                    HTTP::download(subUrl, itemDir + "/" + subFileName, HTTP::Timeout{});
+                                    brls::Logger::info("Downloaded subtitle: {}", subFileName);
+                                } catch (const std::exception& e) {
+                                    brls::Logger::warning("Failed to download subtitle stream {}: {}", stream.Index, e.what());
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (const std::exception& e) {
+                brls::Logger::warning("Failed to fetch item subtitles for download: {}", e.what());
+            }
+        }
+
         auto lastProgress = std::make_shared<std::chrono::steady_clock::time_point>();
         HTTP::Progress::Callback progressCb = [this, itemId, lastProgress](curl_off_t total, curl_off_t now) {
             auto tp = std::chrono::steady_clock::now();


### PR DESCRIPTION
 This PR improves subtitle handling for downloaded media items on Nintendo Switch:
        - Automatically downloads available subtitle streams (`.srt`, `.vtt`, `.ass`) alongside video content in `DownloadManager`.
        - Automatically scans and attaches local downloaded subtitle files upon playback in `RemotePlayer`.
        - Dynamically queries and attaches remote Jellyfin server subtitles on-the-fly when online.

        *Implemented with AI assistance (Google Antigravity), tested on real Nintendo Switch hardware, and verified working.*